### PR TITLE
Multi-variable scattering on multiple chunks

### DIFF
--- a/lib/filterbanks/permute_subscript.m
+++ b/lib/filterbanks/permute_subscript.m
@@ -1,0 +1,24 @@
+function psis = permute_subscript(psis, subscript)
+%% Deep map across cells
+if iscell(psis)
+    for cell_index = 1:numel(psis)
+        if ~isempty(psis{cell_index})
+            psis{cell_index} = permute_subscript(psis{cell_index}, subscript);
+        end
+    end
+    return
+end
+
+%% Compute permutation
+old_subscript = length(drop_trailing(size(psis(1).ft)));
+permutation = 1:subscript;
+permutation(old_subscript) = subscript;
+permutation(subscript) = old_subscript;
+
+%%
+nLambdas = numel(psis);
+for lambda = 1:nLambdas
+    psis(lambda).ft = permute(psis(lambda).ft,permutation);
+end
+end
+

--- a/lib/operators/blur_Y.m
+++ b/lib/operators/blur_Y.m
@@ -22,7 +22,11 @@ catch err
     end
 end
 variable = get_leaf(variable_tree,bank.behavior.key);
+% Subscripts and colons are updated according to the network structure
 bank.behavior.subscripts = variable.subscripts;
+if variable.subscripts(1)>1
+    bank.phi = permute_subscript(bank.phi,bank.behavior.subscripts);
+end
 bank.behavior.colons = substruct('()',replicate_colon(length(keys{1+0})));
 
 %% Blurring

--- a/lib/operators/scatter_Y.m
+++ b/lib/operators/scatter_Y.m
@@ -28,6 +28,9 @@ end
 variable = get_leaf(variable_tree,bank.behavior.key);
 % Subscripts and colons are updated according to the network structure
 bank.behavior.subscripts = variable.subscripts;
+if variable.subscripts(1)>1
+    bank.psis = permute_subscript(bank.psis,bank.behavior.subscripts);
+end
 bank.behavior.colons.subs = replicate_colon(length(keys{1+0}));
 
 %% Scattering

--- a/lib/utilities/drop_trailing.m
+++ b/lib/utilities/drop_trailing.m
@@ -1,7 +1,15 @@
 function dropped_sizes = drop_trailing(sizes,min_dimension)
 if nargin<2
-    dropped_sizes = sizes(1:find(sizes~=1,1,'last'));
+    last_nonsingleton = find(sizes~=1,1,'last');
+    if isempty(last_nonsingleton)
+        last_nonsingleton = 1;
+    end
+    dropped_sizes = sizes(1:last_nonsingleton);
 else
-    dropped_sizes = sizes(1:max(find(sizes~=1,1,'last'),min_dimension));
+    last_nonsingleton = find(sizes~=1,1,'last');
+    if isempty(last_nonsingleton)
+        last_nonsingleton = 1;
+    end
+    dropped_sizes = sizes(1:max(last_nonsingleton,min_dimension));
 end
 end

--- a/research/mlsp15/mlsp_synthesize_scattering.m
+++ b/research/mlsp15/mlsp_synthesize_scattering.m
@@ -5,7 +5,7 @@
 % 4: same, up to the scale of 2 octaves
 % 5: same, up to the scale of 4 octaves
 
-function mlsp_synthesize_accipiter(method_index)
+function mlsp_synthesize_scattering(method_index)
 N = 65536;
 sample_rate =  22050;
 T = N/8;


### PR DESCRIPTION
This PR fixes allows to do multi-variable scattering on signals of arbitrary length. They are padded, chunked, transformed, and unchunked according to the chunk size specified in `archs{1}.banks{1}.spec.size`. Subscript permutation of the filters is made to ensure that the joint scattering transform operates over the right dimension (2 when there is only one chunk, 3 when there are chunks).
