### PR TITLE
Reconstruction with finite difference wavelets

### DIFF
--- a/lib/architecture/setup_plans.m
+++ b/lib/architecture/setup_plans.m
@@ -88,7 +88,7 @@ for layer = 2:nLayers
                     end
                     % If wavelets are replaced by finite differences
                     if strcmp(handle_str, 'finitediff_1d')
-                        field.T = enforce(field, 'T', 3);
+                        field.T = enforce(field, 'T', 2);
                         field.J = enforce(field, 'J', 2);
                         field.nFilters_per_octave = ...
                             enforce(field, 'nFilters_per_octave', 1);

--- a/lib/backward/substract_data.m
+++ b/lib/backward/substract_data.m
@@ -17,6 +17,7 @@ if length(minuend_ranges)>1
     
     % Difference initialization
     difference_data = cell(size(minuend_data));
+    difference_ranges{end-1} = cell(size(minuend_ranges{end-1}));
     
     % Loop over nodes
     for node = 1:numel(minuend_data)

--- a/lib/duality/dual_firstborn_blur.m
+++ b/lib/duality/dual_firstborn_blur.m
@@ -20,7 +20,7 @@ end
 bank_behavior = bank.behavior;
 colons = bank_behavior.colons;
 subscripts = bank_behavior.subscripts;
-signal_support = get_signal_support(data,ranges,subscripts);
+signal_support = get_signal_support(data, ranges, subscripts);
 support_index = log2(bank.spec.size/signal_support) + 1;
 dual_phi = bank.dual_phi{support_index};
 

--- a/lib/duality/dual_firstborn_scatter.m
+++ b/lib/duality/dual_firstborn_scatter.m
@@ -57,7 +57,7 @@ if is_deepest && ~is_oriented
 end
 
 %% DO. Deepest, Oriented
-% e.g. along gamma variable
+% e.g. along gamma variable with analytic wavelets
 if is_deepest && is_oriented && ~is_unspiraled
     % In-place multiply-add in Fourier domain
     for gamma_index = 1:nGammas
@@ -84,7 +84,7 @@ if is_deepest && is_oriented && ~is_unspiraled
 end
 
 %% OS. Oriented, unSpiraled
-% e.g. along j variable after scattering along gamma
+% e.g. along j variable with analytic wavelets after scattering along gamma
 if ~is_deepest && is_oriented && is_unspiraled
     spiral = bank_behavior.spiral;
     spiral_subscript = spiral.subscript;
@@ -134,7 +134,7 @@ if ~is_deepest && is_oriented && is_unspiraled
 end
 
 %% DOS. Deepest, Oriented, unSpiraled
-% e.g. along j variable after blurring along gamma
+% e.g. along j variable with analytic wavelets after blurring along gamma
 if is_deepest && is_oriented && is_unspiraled
     spiral = bank_behavior.spiral;
     spiral_subscript = spiral.subscript;

--- a/lib/duality/dual_firstborn_scatter.m
+++ b/lib/duality/dual_firstborn_scatter.m
@@ -45,7 +45,7 @@ is_unspiraled = isfield(bank_behavior,'spiral') && ...
     ~strcmp(get_suffix(bank_behavior.key),'gamma');
 %% D. Deepest
 % e.g. along time
-if is_deepest && ~is_oriented
+if is_deepest && ~is_oriented && ~is_unspiraled
     for gamma_index = 1:nGammas
         gamma = gammas(gamma_index);
         log2_resampling = enabled_log2_resamplings(gamma_index);

--- a/lib/duality/multiply_fft_inplace.m
+++ b/lib/duality/multiply_fft_inplace.m
@@ -1,5 +1,5 @@
-function y_ft = multiply_fft_inplace(x_ft,filter, ...
-    log2_resampling,colons,subscripts,y_ft)
+function y_ft = multiply_fft_inplace(x_ft, filter, ...
+    log2_resampling, colons, subscripts, y_ft)
 %% In-place Fourier transform
 for subscript = subscripts
     x_ft = fft(x_ft,[],subscript);
@@ -64,7 +64,7 @@ neg_y_ft = bsxfun(@times, neg_x_ft, neg_filter_ft);
 %% Product between x_ft and filter_xt, and reduction into y_ft
 pos_y_range = (1+pos_range_start):(1+pos_range_end);
 colons.subs{subscripts} = pos_y_range;
-y_ft = subsasgn(y_ft, colons,  subsref(y_ft, colons) + pos_y_ft);
+y_ft = subsasgn(y_ft, colons, subsref(y_ft, colons) + pos_y_ft);
 
 neg_y_range = (1+neg_range_start+y_sizes):(1+neg_range_end+y_sizes);
 colons.subs{subscripts} = neg_y_range;

--- a/lib/operators/firstborn_scatter.m
+++ b/lib/operators/firstborn_scatter.m
@@ -67,7 +67,7 @@ end
 
 %% Scattering implementations
 %% []. Not deepest, not oriented, not spiraled
-% e.g. scattering along j with real wavelets after scattering along gamma
+% e.g. real scattering along j after scattering along gamma
 if ~is_deepest && ~is_oriented && ~is_spiraled
     data = cell(nCousins,nEnabled_gammas);
     subsasgn_structure = substruct('()',replicate_colon(input_dimension));
@@ -104,8 +104,8 @@ end
 
 %% DO. Deepest, Oriented
 % e.g. scattering along space for images
-% e.g. scattering along gamma in joint time-frequency scattering
-% e.g. scattering along j after blurring (or bypassing) gamma
+% e.g. analytic scattering along gamma in joint time-frequency scattering
+% e.g. analytic scattering along j after blurring (or bypassing) gamma
 if is_deepest && is_oriented && ~is_spiraled
     data = cell(nEnabled_gammas,1);
     subsasgn_structure = substruct('()',replicate_colon(input_dimension+1));
@@ -124,7 +124,7 @@ if is_deepest && is_oriented && ~is_spiraled
 end
 
 %% DOS. Deepest, Oriented, Spiraled
-% e.g. scattering along gamma in spiral
+% e.g. analytic scattering along gamma in spiral
 if is_deepest && is_oriented && is_spiraled
     data = cell(nEnabled_gammas,1);
     for gamma_index = 1:nEnabled_gammas
@@ -144,8 +144,8 @@ if is_deepest && is_oriented && is_spiraled
 end
 
 %% O. Oriented
-% e.g. scattering along j in after scattering along gamma
-% e.g. scattering along theta in roto-translation scattering
+% e.g. analytic scattering along j after scattering along gamma
+% e.g. analytic scattering along theta in roto-translation scattering
 if ~is_deepest && is_oriented && ~is_spiraled
     data = cell(nCousins,nEnabled_gammas);
     subsasgn_structure = substruct('()',replicate_colon(input_dimension+1));

--- a/research/finitediffs/finitediffs_script.m
+++ b/research/finitediffs/finitediffs_script.m
@@ -1,23 +1,189 @@
-%% Build scattering "architectures", i.e. filter banks and nonlinearities
-opts{1}.time.size = 65536;
-opts{1}.time.T = 2^10;
-opts{1}.time.max_scale = 16*opts{1}.time.T;
+file_path = 'research/gretsi15/Vc-scale-chr-asc.wav';
+[full_waveform, sample_rate] = audioread_compat(file_path);
+N = 2^16;
+target_signal = full_waveform(1:N);
+
+%%
+T = N/4;
+opts{1}.time.T = T;
+opts{1}.time.max_Q = 16;
 opts{1}.time.nFilters_per_octave = 16;
+opts{1}.time.has_duals = true;
+opts{1}.time.gamma_bounds = [1 128];
 
-% Options for scattering along time
-opts{2}.time.handle = @morlet_1d;
+opts{1}.nonlinearity.name = 'uniform_log';
+opts{1}.nonlinearity.denominator = 1e2;
+
+opts{2}.time.T = T;
 opts{2}.time.max_scale = Inf;
-opts{2}.time.U_log2_oversampling = 2;
+opts{2}.time.handle = @morlet_1d;
+opts{2}.time.sibling_mask_factor = 2;
+opts{2}.time.max_Q = 1;
+opts{2}.time.has_duals = true;
+opts{2}.time.U_log2_oversampling = 1;
 
-% Options for scattering along chromas
-opts{2}.gamma.invariance = 'bypassed';
-opts{2}.gamma.U_log2_oversampling = Inf;
+opts{2}.gamma.T = 4 * opts{1}.time.nFilters_per_octave;
+opts{2}.gamma.handle = @morlet_1d;
+opts{2}.gamma.nFilters_per_octave = 2;
+opts{2}.gamma.max_Q = 1;
+opts{2}.gamma.cutoff_in_dB = 1.0;
+opts{2}.gamma.has_duals = true;
+opts{2}.gamma.U_log2_oversampling = 2;
+opts{2}.gamma.S_log2_oversampling = 2;
 
-% Options for scattering along octaves
 opts{2}.j.invariance = 'bypassed';
+opts{2}.j.T = 4;
+opts{2}.j.phi_bw_multiplier = 1;
+opts{2}.j.has_duals = true;
 opts{2}.j.handle = @finitediff_1d;
 
 % Build scattering "architectures", i.e. filter banks and nonlinearities
 archs = sc_setup(opts);
 
+%% 
+reconstruction_opt.verbosity_period = 1;
+reconstruction_opt.signal_display_period = 1;
+reconstruction_opt.learning_rate = 0.1;
+reconstruction_opt.momentum = 0.9;
+reconstruction_opt.bold_driver_accelerator = 1.1;
+reconstruction_opt.bold_driver_brake = 0.5;
 
+%% Forward propagation
+nLayers = length(archs);
+target_S = cell(1,1+nLayers);
+target_U = cell(1,1+nLayers);
+target_Y = cell(1,1+nLayers);
+target_U{1+0} = initialize_variables_auto(size(target_signal));
+target_U{1+0}.data = target_signal;
+for layer = 1:nLayers
+    arch = archs{layer};
+    previous_layer = layer - 1;
+    % Scatter iteratively layer U to get sub-layers Y
+    target_Y{layer} = U_to_Y(target_U{1+previous_layer},arch);
+    % Apply non-linearity to last sub-layer Y to get layer U
+    target_U{1+layer} = Y_to_U(target_Y{layer}{end},arch);
+    % Blur/pool first sub-layer Y to get layer S
+    target_S{1+previous_layer} = Y_to_S(target_Y{layer},arch);
+end
+target_Y{1+nLayers}{1+0} = initialize_Y(target_U{1+nLayers},arch.banks);
+target_S{1+nLayers} = Y_to_S(target_Y{1+nLayers},arch);
+
+%% Initialization
+signal = generate_pink_noise(N);
+signal = signal - mean(signal);
+signal = signal * norm(target_signal)/norm(signal);
+signal = signal + mean(target_signal);
+
+%% Reconstruction
+nIterations = 20;
+
+% Initialization
+reconstruction_opt = fill_reconstruction_opt(reconstruction_opt);
+reconstruction_opt.signal_update = zeros(size(signal));
+if reconstruction_opt.is_verbose
+    max_nDigits = 1 + floor(log10(nIterations));
+    sprintf_format = ['%',num2str(max_nDigits),'d'];
+end
+reconstruction_opt.learning_rate = reconstruction_opt.initial_learning_rate;
+[target_norm,layer_target_norms] = sc_norm(target_S);
+
+%
+S = cell(1,1+nLayers);
+U = cell(1,1+nLayers);
+Y = cell(1,1+nLayers);
+U{1+0} = initialize_variables_auto(size(signal));
+U{1+0}.data = signal;
+for layer = 1:nLayers
+    arch = archs{layer};
+    previous_layer = layer - 1;
+    % Scatter iteratively layer U to get sub-layers Y
+    Y{layer} = U_to_Y(U{1+previous_layer},arch);
+    % Apply non-linearity to last sub-layer Y to get layer U
+    U{1+layer} = Y_to_U(Y{layer}{end},arch);
+    % Blur/pool first sub-layer Y to get layer S
+    S{1+previous_layer} = Y_to_S(Y{layer},arch);
+end
+Y{1+nLayers}{1+0} = initialize_Y(U{1+nLayers},arch.banks);
+S{1+nLayers} = Y_to_S(Y{1+nLayers},arch);
+
+%%
+delta_S = sc_substract(target_S,S);
+previous_signal = signal;
+previous_loss = sc_norm(delta_S);
+delta_signal = sc_backpropagate(delta_S,U,Y,archs);
+
+%% Iterated reconstruction
+iteration = 0;
+while iteration < nIterations
+    tic();
+    %% Signal update
+    [signal,reconstruction_opt] = ...
+        update_reconstruction(previous_signal,delta_signal,reconstruction_opt);
+    
+    %% Scattering propagation
+    U{1+0}.data = signal;
+    for layer = 1:nLayers
+        arch = archs{layer};
+        previous_layer = layer - 1;
+        % Scatter iteratively layer U to get sub-layers Y
+        Y{layer} = U_to_Y(U{1+previous_layer},arch);
+        % Apply non-linearity to last sub-layer Y to get layer U
+        U{1+layer} = Y_to_U(Y{layer}{end},arch);
+        % Blur/pool first sub-layer Y to get layer S
+        S{1+previous_layer} = Y_to_S(Y{layer},arch);
+    end
+    Y{1+nLayers}{1+0} = initialize_Y(U{1+nLayers},arch.banks);
+    S{1+nLayers} = Y_to_S(Y{1+nLayers},arch);
+    
+    %% Measurement of distance to target in the scattering domain
+    delta_S = sc_substract(target_S,S);
+    
+    %% If loss has increased, step retraction and bold driver "brake"
+    [loss,layer_absolute_distances] = sc_norm(delta_S);
+    if loss>previous_loss
+        reconstruction_opt.learning_rate = ...
+            reconstruction_opt.bold_driver_brake * ...
+            reconstruction_opt.learning_rate;
+        reconstruction_opt.signal_update = ...
+            reconstruction_opt.bold_driver_brake * ...
+            reconstruction_opt.signal_update;
+        continue
+    end
+    
+    %% If loss has decreased, step confirmation and bold driver "acceleration"
+    iteration = iteration + 1;
+    previous_signal = signal;
+    previous_loss = loss;
+    reconstruction_opt.learning_rate = ...
+        reconstruction_opt.bold_driver_accelerator * ...
+        reconstruction_opt.learning_rate;
+    [delta_signal, delta_U] = sc_backpropagate(delta_S,U,Y,archs);
+    
+    %% Pretty-printing of scattering distances and loss function
+    if reconstruction_opt.is_verbose
+        mod_iteration = mod(iteration,reconstruction_opt.verbosity_period);
+        if mod_iteration==0
+            pretty_iteration = sprintf(sprintf_format,iteration);
+            relative_loss = 100 * loss / target_norm;
+            layer_distances = ...
+                100 * layer_absolute_distances ./ layer_target_norms;
+            pretty_distances = num2str(layer_distances,'%8.2f%%');
+            pretty_loss = sprintf('%.2f%%',relative_loss);
+            iteration_string = ['it = ',pretty_iteration,'  ;  '];
+            distances_string = ...
+                ['S_m distances = [ ',pretty_distances, ' ]  ;  '];
+            loss_string = ['Loss = ',pretty_loss];
+            disp([iteration_string,distances_string,loss_string]);
+        end
+    end
+    if reconstruction_opt.is_signal_displayed
+        mod_iteration = ...
+            mod(iteration,reconstruction_opt.signal_display_period);
+        if mod_iteration==0
+            sc = display_scalogram(delta_U{1+1});
+            save(['sc_it',int2str(iteration)], 'sc');
+            audiowrite(['w_it',int2str(iteration),'.wav',], signal, sample_rate);
+        end
+    end
+    toc();
+end


### PR DESCRIPTION
This PR implements the required falllback in dual_firstborn_scatter to backpropagate spiral scattering coefficients made with real wavelets (e.g. finite differences) across octaves. It also fixes a bug in substract_data.
A research script for reconstruction of audio signal is included.
